### PR TITLE
adding redirect instead of modal for ride button, including sample usage

### DIFF
--- a/dist/development.multiple.html
+++ b/dist/development.multiple.html
@@ -115,7 +115,7 @@
     /* Configurations */
     /* ============== */
     var configurations = [{
-      clientId: 'SOMNEID',
+      clientId: 'SOME_CLIENT_ID',
       clientToken: '',
       googleApiKey: '',
       locationAddress: 'Golden Gate Bridge, San Francisco, CA',

--- a/dist/development.multiple.html
+++ b/dist/development.multiple.html
@@ -60,6 +60,7 @@
       locationLongitude,
       locationName,
       parentElement,
+      queryParams,
       theme,
       userButtonObjectName,
       userModalObjectName
@@ -101,6 +102,7 @@
             window[userModalObjectName].open();
             return false;
           },
+          'queryParams': queryParams || null,
           'parentElement': parentElement,
           'theme': theme
         });
@@ -113,7 +115,7 @@
     /* Configurations */
     /* ============== */
     var configurations = [{
-      clientId: '',
+      clientId: 'SOMNEID',
       clientToken: '',
       googleApiKey: '',
       locationAddress: 'Golden Gate Bridge, San Francisco, CA',
@@ -121,6 +123,10 @@
       locationLongitude: '-122.4804438',
       locationName: 'Golden Gate Bridge',
       parentElement: document.getElementById('lyft-web-button-parent-1'),
+      query: {
+        credits: 'PROMOCODE',
+        ridetype: 'lyft_line',
+      },
       theme: 'hot-pink small',
       userButtonObjectName: 'lyftWebButton1',
       userModalObjectName: 'lyftWebModal1'
@@ -278,6 +284,7 @@
         configurations[i].locationLongitude,    // locationLongitude
         configurations[i].locationName,         // locationName
         configurations[i].parentElement,        // parentElement
+        configurations[i].query,                // queryParams
         configurations[i].theme,                // theme
         configurations[i].userButtonObjectName, // userButtonObjectName
         configurations[i].userModalObjectName   // userModalObjectName

--- a/dist/development.single.html
+++ b/dist/development.single.html
@@ -46,6 +46,7 @@
       locationLongitude,
       locationName,
       parentElement,
+      queryParams,
       theme,
       userButtonObjectName,
       userModalObjectName
@@ -87,6 +88,7 @@
             window[userModalObjectName].open();
             return false;
           },
+          'queryParams': queryParams || null,
           'parentElement': parentElement,
           'theme': theme
         });
@@ -109,6 +111,9 @@
       '-122.3913909',                                       // locationLongitude
       'Lyft HQ',                                            // locationName
       document.getElementById('lyft-web-button-parent'),    // parentElement
+      {
+        credits: 'PROMOCODE'
+      },                                   // queryParams
       'multicolor large',                                   // theme
       'lyftWebButton',                                      // userButtonObjectName
       'lyftWebModal'                                        // userModalObjectName

--- a/src/components/lyftWebButton/index.js
+++ b/src/components/lyftWebButton/index.js
@@ -1,6 +1,7 @@
 // dependencies
 var api = require('../../services/api.js');
 var selector = require('../../services/selector.js');
+var serialize = require('../../services/serialize.js');
 
 // styles
 require('./index.css');
@@ -43,10 +44,33 @@ function createElements() {
  * @param {function} onClick Handler for button's onclick event.
  * @returns {void} Void.
  */
-function bindEvents(onClick) {
-  // root element: bind user-specified event handler
-  if (rootElement) {
-    rootElement.onclick = onClick;
+function bindEvents(rootEl, options) {
+  let redirectURI = 'https://ride.lyft.com';
+
+  if (rootEl) {
+    let queryParams;
+
+    if (options.queryParams) {
+      // assign the query parameters from the options
+      queryParams = options.queryParams;
+    }
+
+    if (options.clientId !== '' || undefined) {
+      // if we have a clientId, let's assign it to the `partner` on the query string
+      queryParams.partner = options.clientId;
+    }
+
+    if (queryParams) {
+      // if we have any parameters, redirect to the full query string
+      redirectURI = `${redirectURI}/?${serialize(queryParams)}`;
+    }
+
+    if (redirectURI) {
+      rootEl.onclick = (e) => {
+        e.preventDefault();
+        window.open(redirectURI);
+      };
+    }
   }
 }
 
@@ -142,7 +166,7 @@ function initialize(options) {
   }
   // create element tree
   createElements();
-  bindEvents(options.onClick);
+  bindEvents(rootElement, options);
   updateContents(options.theme);
   // insert element into DOM
   options.parentElement.insertBefore(rootElement, options.parentElement.childNodes[0]);

--- a/src/services/serialize.js
+++ b/src/services/serialize.js
@@ -1,0 +1,19 @@
+/**
+ * Serializes an object to a query string; ensures each key is not null.
+ * @memberOf serialize
+ * @category serialize
+ * @param {Object} obj Required.
+ * @returns {String} String.
+ */
+module.exports = function (obj) {
+  var str = [];
+  if (!obj) {
+    return '';
+  }
+  for (var p in obj)    {
+    if (obj.hasOwnProperty(p) && obj[p] !== null) {
+      str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
+    }
+  }
+  return str.join('&');
+};


### PR DESCRIPTION
This should work as expected.
![screen recording 2017-03-30 at 06 00 pm](https://cloud.githubusercontent.com/assets/273842/24532256/fb37a6a0-1573-11e7-9446-7eedd9cb59ca.gif)

If you can't see in the logs, what happens is, if the parameters aren't provided for the `queryParams` object, it'll just pop open a window to https://ride.lyft.com.

If a `clientID` is the only thing provided, it will open a window with the params sent over:
`https://ride.lyft.com/partner=SOME_CLIENT_ID`

If the other parameters are provided, it'll merge them:
`https://ride.lyft.com/partner=SOME_CLIENT_ID&credits=PROMOCODE`. 

I'm not checking for validity against the possible provided parameters, we could if you like.

In the repo, I'm setting up the first one in the `multiple` bundle to show an example usage. The rest are leaving the `clientID` and `queryParams` blank/empty.
![image](https://cloud.githubusercontent.com/assets/273842/24532315/6b0facde-1574-11e7-86a9-308cd187ffe5.png)